### PR TITLE
fix: propagate logLevel and cacheEnabled config values to their consumers

### DIFF
--- a/.github/agents/slop-reviewer.md
+++ b/.github/agents/slop-reviewer.md
@@ -1,0 +1,156 @@
+---
+name: Slop Reviewer
+description: Reviews code for typcial markers of AI-Slop
+argument-hint: 
+tools:
+  [vscode/askQuestions, vscode/runCommand, execute/getTerminalOutput, execute/createAndRunTask, execute/runTests, execute/testFailure, execute/runInTerminal, read/terminalSelection, read/terminalLastCommand, read/getTaskOutput, read/problems, read/readFile, edit/createFile, search, web, todo, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/activePullRequest]
+infer: true
+---
+
+# De-Sloppification Agent Instructions
+
+**Worktree awareness**: Other agents may be working concurrently. Do not modify files containing untracked or tracked worktree changes that you did not create. Verify with `git status` before editing.
+
+You are a De-Sloppification agent for JsonDbApp. Your job is to inspect a codebase, or a clearly scoped subset of it, for AI-slop: code that is technically present but materially unnecessary, over-engineered, duplicated, stale, or suspiciously brittle.
+
+The goal is not to produce generic clean-code feedback. The goal is to find concrete places where the code looks like it was produced by a model that optimised for completion rather than maintainability.
+
+## 0. Mandatory First Step
+
+Before reviewing or editing anything, you must:
+
+1. **Acquire context**:
+   - Read the files in scope.
+   - Read nearby tests and call sites when they exist.
+   - Read enough surrounding code to understand the local pattern before judging it.
+2. **Read standards**:
+   - Read AGENTS.md.
+   - Read the component-specific `AGENTS.md` for every area you touch.
+   - Read in-scope canonical policy docs before judging slop (for frontend scope this includes frontend helper/abstraction standards and related canonical frontend docs).
+3. **Establish scope**:
+   - Identify the exact package, directory, or feature slice under review.
+   - Separate confirmed slop from mere style preference.
+   - Expect the handoff prompt to include the relevant source snippets, concrete requirements, error/output details, and exact changes already made.
+4. **Check dependencies and APIs**:
+   - Inspect package manifests, lockfiles, imports, and current runtime usage before calling something outdated.
+   - Use web research only when freshness matters and the repository context does not already answer the question.
+
+Do not start from broad clean-code platitudes. Start from the actual code and prove each claim.
+
+## 1. What Counts As Slop
+
+Prioritise findings in this order:
+
+1. **Dead or stale code**:
+   - unused exports, unused helpers, commented-out blocks, obsolete branches, redundant shims, and scaffolding left behind after a previous iteration
+2. **Duplicated logic**:
+   - cloned functions, copy-pasted conditionals, repeated normalisation logic, repeated mapping or formatting code, and needless pass-through wrappers
+3. **Unnecessary complexity**:
+   - helpers with one caller, abstractions that hide simple behaviour, nested control flow created to support hypothetical future cases, and over-general APIs
+4. **Suspicious defensive code**:
+   - guards around known-internal modules, catch-and-ignore patterns, broad feature detection, and double validation of already validated data
+5. **Outdated or mismatched dependencies**:
+   - deprecated APIs, stale library usage, compatibility shims that no longer fit the runtime, and versioned workarounds that the code no longer needs
+6. **Generated-code tells**:
+   - cargo-cult comments, placeholder TODOs, overly generic names, inconsistent error handling, overly verbose glue code, and behaviour that only exists to satisfy an imagined edge case
+7. **Policy deviations**:
+   - behaviour that conflicts with canonical policy docs, including helper-standard and abstraction rules
+
+If a candidate does not clearly fit one of these categories, keep investigating before reporting it.
+
+## 2. Slop-Hunting Workflow
+
+Work in a strict sequence:
+
+1. **Map the area**
+   - Identify the modules, files, and call paths that are most likely to contain slop.
+   - Look for recent additions, helper-heavy modules, utility layers, and code with many one-line wrappers.
+2. **Search aggressively**
+   - Compare similar files and functions.
+   - Search for duplicate strings, repeated conditionals, repeated error handling, and near-identical logic.
+   - Check for stale imports, unused exports, dead branches, and commented-out code.
+3. **Test the necessity**
+   - Ask whether each abstraction has more than one real caller.
+   - Ask whether each guard protects a real boundary or just expresses fear.
+   - Ask whether each fallback or compatibility branch is still required by the runtime or build pipeline.
+   - Check whether the candidate change deviates from canonical policy docs rather than only from style preference.
+4. **Prefer removal over addition**
+   - Delete dead code.
+   - Inline one-off helpers.
+   - Collapse pass-through wrappers.
+   - Simplify branching before extracting new helpers.
+   - Only introduce a new abstraction if it removes proven duplication across multiple real call sites.
+5. **Verify impact**
+   - If you edit code, run the smallest relevant validation first, then the broader checks required by the touched module(s).
+   - Re-read the edited files after changes and confirm the simplification did not create a new indirection layer.
+
+## 3. Evidence Rules
+
+Do not report a slop finding unless you can point to concrete evidence:
+
+- file path and line numbers
+- the exact smell
+- why the code is unnecessary, duplicated, stale, or misleading
+- what should happen instead
+
+If the evidence is weak, label it as a hypothesis and keep investigating. Do not inflate uncertainty into a finding.
+
+## 4. Cleanup Rules
+
+When cleanup is justified:
+
+- Keep changes minimal and localised.
+- Remove code before creating new code.
+- Preserve existing behaviour unless the explicit goal is to change it.
+- Do not normalise everything into a new abstraction just because it is possible.
+- Do not add defaults, fallback magic, or compatibility scaffolding unless the repository explicitly needs them.
+- Do not silence errors or bury problems behind broader try/catch blocks.
+
+If a cleanup spans active modules, follow the component-specific `AGENTS.md` for each module and respect the module's validation commands.
+
+## 5. Validation Expectations
+
+If you edit files, validate the touched area before returning work:
+
+- run the relevant lint and test commands for each touched module
+- use the repository's preferred commands rather than inventing new ones
+- treat a failing validation as a reason to fix the code, not to soften the report
+
+If validation is unavailable in the environment, state the limitation explicitly and explain what remains unverified.
+
+## 6. Reporting Format
+
+Return findings in this order:
+
+- **Summary**: Pass / Needs Improvement / Fail, with one sentence on the overall slop profile
+- **Critical**: confirmed dead code, duplicated logic, misleading abstractions, or clearly obsolete dependencies that should be removed
+- **Improvement**: simplifications that would materially reduce maintenance cost but are not immediately blocking
+- **Nitpick**: cosmetic or naming issues that are only worth fixing if they fall out of a larger cleanup
+
+For each item, include:
+
+- location
+- evidence
+- why it matters
+- recommended simplification
+
+For policy-deviation findings, include:
+
+- violated policy doc and rule
+- impact
+- required correction
+- blocker status (`yes` or `no`)
+
+## 7. Completion
+
+When the review is complete:
+
+- state whether the codebase is clean of confirmed slop or whether blocking items remain
+- list any cleanup work you actually performed
+- list the validation commands you ran and their outcomes
+- call out any areas you could not verify
+- include a `Files read` section with explicit file paths for mandatory docs and canonical policies consulted
+
+Do not mark the review clean while unresolved canonical-policy deviations remain.
+
+Do not confuse breadth with quality. A good review finds the smallest number of concrete changes that remove the most slop.

--- a/.github/agents/slop-reviewer.md
+++ b/.github/agents/slop-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: Slop Reviewer
 description: Reviews code for typical markers of AI-Slop
-argument-hint:
 tools:
   [
     vscode/askQuestions,
@@ -23,7 +22,6 @@ tools:
     github.vscode-pull-request-github/issue_fetch,
     github.vscode-pull-request-github/activePullRequest
   ]
-infer: true
 ---
 
 # De-Sloppification Agent Instructions

--- a/.github/agents/slop-reviewer.md
+++ b/.github/agents/slop-reviewer.md
@@ -1,9 +1,28 @@
 ---
 name: Slop Reviewer
 description: Reviews code for typcial markers of AI-Slop
-argument-hint: 
+argument-hint:
 tools:
-  [vscode/askQuestions, vscode/runCommand, execute/getTerminalOutput, execute/createAndRunTask, execute/runTests, execute/testFailure, execute/runInTerminal, read/terminalSelection, read/terminalLastCommand, read/getTaskOutput, read/problems, read/readFile, edit/createFile, search, web, todo, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/activePullRequest]
+  [
+    vscode/askQuestions,
+    vscode/runCommand,
+    execute/getTerminalOutput,
+    execute/createAndRunTask,
+    execute/runTests,
+    execute/testFailure,
+    execute/runInTerminal,
+    read/terminalSelection,
+    read/terminalLastCommand,
+    read/getTaskOutput,
+    read/problems,
+    read/readFile,
+    edit/createFile,
+    search,
+    web,
+    todo,
+    github.vscode-pull-request-github/issue_fetch,
+    github.vscode-pull-request-github/activePullRequest
+  ]
 infer: true
 ---
 

--- a/.github/agents/slop-reviewer.md
+++ b/.github/agents/slop-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: Slop Reviewer
-description: Reviews code for typcial markers of AI-Slop
+description: Reviews code for typical markers of AI-Slop
 argument-hint:
 tools:
   [

--- a/docs/developers/Database.md
+++ b/docs/developers/Database.md
@@ -176,6 +176,8 @@ class Database {
 
 - Validates and normalizes configuration via DatabaseConfig
 - initialises logging, file services, and MasterIndex
+- Propagates `logLevel` config to `JDbLogger` via `setLevelByName()` so all subsequent log output respects the configured level
+- Propagates `cacheEnabled` config to `FileService` via `setCacheEnabled()` (defaults to `true`)
 - Creates in-memory collections map
 - Does NOT automatically initialise - call `initialise()` explicitly
 

--- a/docs/developers/Infrastructure_Components.md
+++ b/docs/developers/Infrastructure_Components.md
@@ -66,7 +66,7 @@ A comprehensive logging utility providing structured logging with multiple level
 | Method                             | Description                                   |
 | ---------------------------------- | --------------------------------------------- |
 | `setLevel(level)`                  | Set log level by number (0-3)                 |
-| `setLevelByName(name)`             | Set log level by name (ERROR/WARN/INFO/DEBUG) |
+| `setLevelByName(name)`             | Set log level by name (ERROR/WARN/INFO/DEBUG). Called automatically by `Database` constructor to propagate `logLevel` config. |
 | `error(message, context)`          | Log error message with optional context       |
 | `warn(message, context)`           | Log warning message with optional context     |
 | `info(message, context)`           | Log info message with optional context        |
@@ -622,7 +622,10 @@ class Collection {
 ### 1.4.1. Logger Configuration
 
 ```javascript
-// Set global log level
+// When using Database, the constructor propagates logLevel automatically:
+const db = new Database({ logLevel: 'DEBUG' }); // JDbLogger.setLevelByName('DEBUG') called internally
+
+// Manual override (e.g., for standalone scripts or testing):
 JDbLogger.setLevelByName('DEBUG'); // Development
 JDbLogger.setLevelByName('INFO'); // Production
 

--- a/docs/developers/Infrastructure_Components.md
+++ b/docs/developers/Infrastructure_Components.md
@@ -63,16 +63,16 @@ A comprehensive logging utility providing structured logging with multiple level
 
 ### 1.2.0.2. Core Methods
 
-| Method                             | Description                                   |
-| ---------------------------------- | --------------------------------------------- |
-| `setLevel(level)`                  | Set log level by number (0-3)                 |
+| Method                             | Description                                                                                                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `setLevel(level)`                  | Set log level by number (0-3)                                                                                                 |
 | `setLevelByName(name)`             | Set log level by name (ERROR/WARN/INFO/DEBUG). Called automatically by `Database` constructor to propagate `logLevel` config. |
-| `error(message, context)`          | Log error message with optional context       |
-| `warn(message, context)`           | Log warning message with optional context     |
-| `info(message, context)`           | Log info message with optional context        |
-| `debug(message, context)`          | Log debug message with optional context       |
-| `createComponentLogger(component)` | Create component-specific logger              |
-| `timeOperation(name, fn, context)` | Time and log operation execution              |
+| `error(message, context)`          | Log error message with optional context                                                                                       |
+| `warn(message, context)`           | Log warning message with optional context                                                                                     |
+| `info(message, context)`           | Log info message with optional context                                                                                        |
+| `debug(message, context)`          | Log debug message with optional context                                                                                       |
+| `createComponentLogger(component)` | Create component-specific logger                                                                                              |
+| `timeOperation(name, fn, context)` | Time and log operation execution                                                                                              |
 
 ### 1.2.0.3. Usage Examples
 

--- a/docs/release-notes/release-notes-v0.1.2.md
+++ b/docs/release-notes/release-notes-v0.1.2.md
@@ -1,0 +1,23 @@
+## JsonDbApp v0.1.2 — Patch release
+
+Release date: 2026-06-04
+
+### Summary
+
+This patch release fixes two config propagation bugs where `logLevel` and `cacheEnabled` settings supplied via `DatabaseConfig` were not applied at runtime. `JDbLogger.currentLevel` was hardcoded to `DEBUG` and `FileService._cacheEnabled` was hardcoded to `true`, ignoring user configuration.
+
+### Fixes
+
+- **`logLevel` not propagated to `JDbLogger`:** The `Database` constructor now calls `JDbLogger.setLevelByName(this.config.logLevel)` before creating any component loggers, ensuring all subsequent log output respects the configured level. Previously, `JDbLogger.currentLevel` was unconditionally set to `DEBUG` at class-load time and never updated from config.
+- **`cacheEnabled` not propagated to `FileService`:** The `Database` constructor now calls `this._fileService.setCacheEnabled(this.config.cacheEnabled)` after `FileService` creation. Previously, `FileService` hardcoded `this._cacheEnabled = true` in its constructor with no way for `Database` to propagate the user's preference.
+
+### Tests added
+
+- 7 regression tests in `tests/unit/database/database-initialisation.test.js` under a new `Config propagation` describe block:
+  - 4 tests verifying `logLevel` propagation (`ERROR`, `WARN`, `INFO`, `DEBUG`)
+  - 3 tests verifying `cacheEnabled` propagation (`true`, `false`, default)
+
+### Upgrade notes
+
+- No breaking changes.
+- No configuration changes required; existing configs now work as originally intended.

--- a/docs/release-notes/release-notes-v0.1.2.md
+++ b/docs/release-notes/release-notes-v0.1.2.md
@@ -9,7 +9,7 @@ This patch release fixes two config propagation bugs where `logLevel` and `cache
 ### Fixes
 
 - **`logLevel` not propagated to `JDbLogger`:** The `Database` constructor now calls `JDbLogger.setLevelByName(this.config.logLevel)` before creating any component loggers, ensuring all subsequent log output respects the configured level. Previously, `JDbLogger.currentLevel` was unconditionally set to `DEBUG` at class-load time and never updated from config.
-- **`cacheEnabled` not propagated to `FileService`:** The `Database` constructor now calls `this._fileService.setCacheEnabled(this.config.cacheEnabled)` after `FileService` creation. Previously, `FileService` hardcoded `this._cacheEnabled = true` in its constructor with no way for `Database` to propagate the user's preference.
+- **`cacheEnabled` not propagated to `FileService`:** The `Database` constructor now calls `this._fileService.setCacheEnabled(this.config.cacheEnabled)` after `FileService` creation. Previously, `FileService` hardcoded `this._cacheEnabled = true` in its constructor, and `Database` did not call the existing `setCacheEnabled()` method to apply the user's preference.
 
 ### Tests added
 

--- a/src/04_core/Database/99_Database.js
+++ b/src/04_core/Database/99_Database.js
@@ -31,9 +31,17 @@ class Database {
 
     this.indexFileId = null;
     this.collections = new Map();
+
+    // Apply log-level configuration before creating the component logger
+    // so that all subsequent log output respects the configured level.
+    JDbLogger.setLevelByName(this.config.logLevel);
     this._logger = JDbLogger.createComponentLogger('Database');
+
     this._fileOps = new FileOperations(this._logger, this.config);
     this._fileService = new FileService(this._fileOps, this._logger);
+    // FileService defaults cacheEnabled to true; propagate the configured value.
+    this._fileService.setCacheEnabled(this.config.cacheEnabled);
+
     this._masterIndex = null;
 
     this._lifecycle = new DatabaseLifecycle(this);

--- a/tests/unit/database/database-initialisation.test.js
+++ b/tests/unit/database/database-initialisation.test.js
@@ -229,33 +229,55 @@ describe('Database Initialisation', () => {
     });
 
     it('should propagate cacheEnabled: false to FileService', () => {
-      // Arrange & Act - Create Database with cacheEnabled explicitly disabled
-      const { database } = setupDatabaseTestEnvironment({ cacheEnabled: false });
+      // Arrange - Save JDbLogger level (mutated by Database constructor) to restore after test
+      const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with cacheEnabled explicitly disabled
+        const { database } = setupDatabaseTestEnvironment({ cacheEnabled: false });
 
-      // Assert - FileService should reflect disabled cache
-      expect(database.config.cacheEnabled).toBe(false);
-      const cacheStats = database._fileService.getCacheStats();
-      expect(cacheStats.enabled).toBe(false);
+        // Assert - FileService should reflect disabled cache
+        expect(database.config.cacheEnabled).toBe(false);
+        const cacheStats = database._fileService.getCacheStats();
+        expect(cacheStats.enabled).toBe(false);
+      } finally {
+        // Cleanup - Restore original JDbLogger level
+        JDbLogger.setLevel(originalLevel);
+      }
     });
 
     it('should propagate explicit cacheEnabled: true to FileService', () => {
-      // Arrange & Act - Create Database with cacheEnabled explicitly enabled
-      const { database } = setupDatabaseTestEnvironment({ cacheEnabled: true });
+      // Arrange - Save JDbLogger level (mutated by Database constructor) to restore after test
+      const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with cacheEnabled explicitly enabled
+        const { database } = setupDatabaseTestEnvironment({ cacheEnabled: true });
 
-      // Assert - FileService should have cache enabled
-      expect(database.config.cacheEnabled).toBe(true);
-      const cacheStats = database._fileService.getCacheStats();
-      expect(cacheStats.enabled).toBe(true);
+        // Assert - FileService should have cache enabled
+        expect(database.config.cacheEnabled).toBe(true);
+        const cacheStats = database._fileService.getCacheStats();
+        expect(cacheStats.enabled).toBe(true);
+      } finally {
+        // Cleanup - Restore original JDbLogger level
+        JDbLogger.setLevel(originalLevel);
+      }
     });
 
     it('should propagate cacheEnabled default of true to FileService', () => {
-      // Arrange & Act - Create Database with default config
-      const { database } = setupDatabaseTestEnvironment();
+      // Arrange - Save JDbLogger level (mutated by Database constructor) to restore after test
+      const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with default config
+        const { database } = setupDatabaseTestEnvironment();
 
-      // Assert - FileService should have cache enabled by default
-      expect(database.config.cacheEnabled).toBe(true);
-      const cacheStats = database._fileService.getCacheStats();
-      expect(cacheStats.enabled).toBe(true);
+        // Assert - FileService should have cache enabled by default
+        expect(database.config.cacheEnabled).toBe(true);
+        expect(database.config.logLevel).toBe('INFO');
+        const cacheStats = database._fileService.getCacheStats();
+        expect(cacheStats.enabled).toBe(true);
+      } finally {
+        // Cleanup - Restore original JDbLogger level
+        JDbLogger.setLevel(originalLevel);
+      }
     });
   });
 });

--- a/tests/unit/database/database-initialisation.test.js
+++ b/tests/unit/database/database-initialisation.test.js
@@ -1,4 +1,4 @@
-/* global Database, DatabaseConfig, MasterIndex, PropertiesService, MasterIndexError */
+/* global Database, DatabaseConfig, MasterIndex, PropertiesService, MasterIndexError, JDbLogger */
 
 /**
  * Database Initialisation Tests
@@ -167,34 +167,68 @@ describe('Database Initialisation', () => {
     it('should propagate logLevel config to JDbLogger', () => {
       // Arrange - Save original level to restore after test
       const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with explicit logLevel
+        const { database } = setupDatabaseTestEnvironment({ logLevel: 'ERROR' });
 
-      // Act - Create Database with explicit logLevel
-      const { database } = setupDatabaseTestEnvironment({ logLevel: 'ERROR' });
-
-      // Assert - JDbLogger.currentLevel should match configured logLevel
-      expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.ERROR);
-      expect(database.config.logLevel).toBe('ERROR');
-
-      // Cleanup - Restore original log level
-      JDbLogger.setLevel(originalLevel);
+        // Assert - JDbLogger.currentLevel should match configured logLevel
+        expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.ERROR);
+        expect(database.config.logLevel).toBe('ERROR');
+      } finally {
+        // Cleanup - Restore original log level
+        JDbLogger.setLevel(originalLevel);
+      }
     });
 
     it('should propagate logLevel default of INFO to JDbLogger', () => {
       // Arrange - Save original level to restore after test
       const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with default config (logLevel defaults to INFO)
+        const { database } = setupDatabaseTestEnvironment();
 
-      // Act - Create Database with default config (logLevel defaults to INFO)
-      const { database } = setupDatabaseTestEnvironment();
-
-      // Assert - JDbLogger.currentLevel should be INFO by default
-      expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.INFO);
-      expect(database.config.logLevel).toBe('INFO');
-
-      // Cleanup - Restore original log level
-      JDbLogger.setLevel(originalLevel);
+        // Assert - JDbLogger.currentLevel should be INFO by default
+        expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.INFO);
+        expect(database.config.logLevel).toBe('INFO');
+      } finally {
+        // Cleanup - Restore original log level
+        JDbLogger.setLevel(originalLevel);
+      }
     });
 
-    it('should propagate cacheEnabled config to FileService', () => {
+    it('should propagate WARN logLevel to JDbLogger', () => {
+      // Arrange - Save original level to restore after test
+      const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with WARN logLevel
+        const { database } = setupDatabaseTestEnvironment({ logLevel: 'WARN' });
+
+        // Assert - JDbLogger.currentLevel should match WARN
+        expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.WARN);
+        expect(database.config.logLevel).toBe('WARN');
+      } finally {
+        // Cleanup - Restore original log level
+        JDbLogger.setLevel(originalLevel);
+      }
+    });
+
+    it('should propagate DEBUG logLevel to JDbLogger', () => {
+      // Arrange - Save original level to restore after test
+      const originalLevel = JDbLogger.getLevel();
+      try {
+        // Act - Create Database with DEBUG logLevel
+        const { database } = setupDatabaseTestEnvironment({ logLevel: 'DEBUG' });
+
+        // Assert - JDbLogger.currentLevel should match DEBUG
+        expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.DEBUG);
+        expect(database.config.logLevel).toBe('DEBUG');
+      } finally {
+        // Cleanup - Restore original log level
+        JDbLogger.setLevel(originalLevel);
+      }
+    });
+
+    it('should propagate cacheEnabled: false to FileService', () => {
       // Arrange & Act - Create Database with cacheEnabled explicitly disabled
       const { database } = setupDatabaseTestEnvironment({ cacheEnabled: false });
 
@@ -202,6 +236,16 @@ describe('Database Initialisation', () => {
       expect(database.config.cacheEnabled).toBe(false);
       const cacheStats = database._fileService.getCacheStats();
       expect(cacheStats.enabled).toBe(false);
+    });
+
+    it('should propagate explicit cacheEnabled: true to FileService', () => {
+      // Arrange & Act - Create Database with cacheEnabled explicitly enabled
+      const { database } = setupDatabaseTestEnvironment({ cacheEnabled: true });
+
+      // Assert - FileService should have cache enabled
+      expect(database.config.cacheEnabled).toBe(true);
+      const cacheStats = database._fileService.getCacheStats();
+      expect(cacheStats.enabled).toBe(true);
     });
 
     it('should propagate cacheEnabled default of true to FileService', () => {

--- a/tests/unit/database/database-initialisation.test.js
+++ b/tests/unit/database/database-initialisation.test.js
@@ -162,4 +162,56 @@ describe('Database Initialisation', () => {
       expect(listedCollections).toContain('sanitizeThis');
     });
   });
+
+  describe('Config propagation', () => {
+    it('should propagate logLevel config to JDbLogger', () => {
+      // Arrange - Save original level to restore after test
+      const originalLevel = JDbLogger.getLevel();
+
+      // Act - Create Database with explicit logLevel
+      const { database } = setupDatabaseTestEnvironment({ logLevel: 'ERROR' });
+
+      // Assert - JDbLogger.currentLevel should match configured logLevel
+      expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.ERROR);
+      expect(database.config.logLevel).toBe('ERROR');
+
+      // Cleanup - Restore original log level
+      JDbLogger.setLevel(originalLevel);
+    });
+
+    it('should propagate logLevel default of INFO to JDbLogger', () => {
+      // Arrange - Save original level to restore after test
+      const originalLevel = JDbLogger.getLevel();
+
+      // Act - Create Database with default config (logLevel defaults to INFO)
+      const { database } = setupDatabaseTestEnvironment();
+
+      // Assert - JDbLogger.currentLevel should be INFO by default
+      expect(JDbLogger.getLevel()).toBe(JDbLogger.LOG_LEVELS.INFO);
+      expect(database.config.logLevel).toBe('INFO');
+
+      // Cleanup - Restore original log level
+      JDbLogger.setLevel(originalLevel);
+    });
+
+    it('should propagate cacheEnabled config to FileService', () => {
+      // Arrange & Act - Create Database with cacheEnabled explicitly disabled
+      const { database } = setupDatabaseTestEnvironment({ cacheEnabled: false });
+
+      // Assert - FileService should reflect disabled cache
+      expect(database.config.cacheEnabled).toBe(false);
+      const cacheStats = database._fileService.getCacheStats();
+      expect(cacheStats.enabled).toBe(false);
+    });
+
+    it('should propagate cacheEnabled default of true to FileService', () => {
+      // Arrange & Act - Create Database with default config
+      const { database } = setupDatabaseTestEnvironment();
+
+      // Assert - FileService should have cache enabled by default
+      expect(database.config.cacheEnabled).toBe(true);
+      const cacheStats = database._fileService.getCacheStats();
+      expect(cacheStats.enabled).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes **two** config propagation bugs where `DatabaseConfig` values were stored but never applied to their consumers:

### Bug 1: `logLevel` config ignored
`JDbLogger.currentLevel` was hardcoded to `DEBUG` in `JDbLogger.js` and never updated from the user-provided `logLevel` config. The `JDbLogger.setLevelByName()` method existed but had **zero callers** in the codebase. Setting `logLevel: "INFO"` or `logLevel: "ERROR"` in the config had no effect — debug logs were always emitted.

**Fix**: Added `JDbLogger.setLevelByName(this.config.logLevel)` in the `Database` constructor, called **before** the component logger is created so all subsequent log output respects the configured level.

### Bug 2: `cacheEnabled` config ignored
`DatabaseConfig.cacheEnabled` was stored and validated correctly, but the `FileService` constructor hardcoded `this._cacheEnabled = true`. The `FileService.setCacheEnabled()` method existed but was never invoked.

**Fix**: Added `this._fileService.setCacheEnabled(this.config.cacheEnabled)` in the `Database` constructor after `FileService` creation.

### Full Config Audit
Traced all 18 properties defined in `DatabaseConfig` — these were the **only two** config values that weren't being propagated to their consumers.

## Changes

| File | Change |
|---|---|
| `src/04_core/Database/99_Database.js` | +3 lines in constructor for config propagation |
| `tests/unit/database/database-initialisation.test.js` | +7 regression tests (covers ERROR, INFO, WARN, DEBUG log levels + explicit `false`, explicit `true`, and default `cacheEnabled`) |
| `docs/developers/Database.md` | Updated constructor behaviour section |
| `docs/developers/Infrastructure_Components.md` | Updated `setLevelByName` docs |
| `docs/release-notes/release-notes-v0.1.2.md` | New release note |

## Verification

- **Lint**: 0 errors, 0 warnings
- **Tests**: 741 passed (69 test files, +3 new test cases from coverage expansion)
- **Code Review Agent**: Reviewed and approved
- **Test Review Agent**: All issues addressed
- **Docs Review Agent**: Developer docs and release notes updated

Closes #53